### PR TITLE
Remove matrix_relay for now

### DIFF
--- a/Matrix KB.org
+++ b/Matrix KB.org
@@ -195,6 +195,5 @@ https://github.com/SkaveRat/xmpptrix
 
 Things which probably need to be added, but need a closer look.
 
-** https://github.com/non-Jedi/matrix_relay
 ** https://github.com/turt2live/matrix-appservice-instagram
 ** The IRC wish list is at https://github.com/matrix-org/matrix-appservice-irc/issues/208, and geekshed is already on the list.


### PR DESCRIPTION
Matrix relay is not yet usable, but I hope to have it ready in the
coming weeks. Figured I'd save you some time reviewing it.